### PR TITLE
Handle `typeof ClassName`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,13 @@ class Context {
         if (strIndex) return {type: "Object", typeArgs: [this.getType(strIndex)]}
         if (numIndex) return {type: "Array", typeArgs: [this.getType(numIndex)]}
 
-        if (objFlags & ObjectFlags.Anonymous) return this.getObjectType(type as ObjectType)
+        if (objFlags & ObjectFlags.Anonymous) {
+          // This uses the logic in `createAnonymousTypeNode` as exposed by `typeToTypeNode`.
+          if (this.tc.typeToTypeNode(type)!.kind === SyntaxKind.TypeQuery) {
+            return {type: "typeof", typeArgs: [this.getReferenceType(type.symbol)]}
+          }
+          return this.getObjectType(type as ObjectType)
+        }
       }
 
       return this.getReferenceType(type.symbol, (type as TypeReference).typeArguments, type)

--- a/test/cases/typeof.json
+++ b/test/cases/typeof.json
@@ -1,0 +1,40 @@
+{
+  "X": {
+    "kind": "class",
+    "id": "X",
+    "loc": {
+      "file": "test/cases/typeof.ts",
+      "line": 1,
+      "column": 0
+    },
+    "type": "class"
+  },
+  "x": {
+    "kind": "function",
+    "id": "x",
+    "loc": {
+      "file": "test/cases/typeof.ts",
+      "line": 3,
+      "column": 0
+    },
+    "type": "Function",
+    "params": [
+      {
+        "name": "LocalX",
+        "id": "x^LocalX",
+        "type": "typeof",
+        "typeArgs": [
+          {
+            "type": "X",
+            "typeSource": "test/cases/typeof.ts"
+          }
+        ],
+        "loc": {
+          "file": "test/cases/typeof.ts",
+          "line": 3,
+          "column": 18
+        }
+      }
+    ]
+  }
+}

--- a/test/cases/typeof.ts
+++ b/test/cases/typeof.ts
@@ -1,0 +1,3 @@
+export class X {}
+
+export function x(LocalX: typeof X) {}


### PR DESCRIPTION
This uses the logic in `createAnonymousTypeNode` as exposed by `typeToTypeNode`. It's probably really easy to extract the relevant conditionals but I don't see through this TypeScript gibberish (yet) …